### PR TITLE
Add support for dashes in bookmark names.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -40,7 +40,7 @@ class syntax_plugin_bookmark extends DokuWiki_Syntax_Plugin {
     function getSort(){ return 357; }
  
     function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('<BOOKMARK:\w+>',$mode,'plugin_bookmark');
+        $this->Lexer->addSpecialPattern('<BOOKMARK:[\w-]+>',$mode,'plugin_bookmark');
     }
  
  


### PR DESCRIPTION
It's fairly common to use - characters in anchor tags; this change makes it legal.